### PR TITLE
Python 3.9.6 in Mac, error in example code because of base.py <--fixed!

### DIFF
--- a/src/igrf/base.py
+++ b/src/igrf/base.py
@@ -128,20 +128,20 @@ def igrf(
             Bnorth[i], Beast[i], Bvert[i], Btotal[i] = list(map(float, ret.stdout.split()))
 
     # %% assemble output
+    decl, incl = mag_vector2incl_decl(Bnorth, Beast, Bvert)
+
     mag = xarray.Dataset(
         {
             "north": ("alt_km", Bnorth),
             "east": ("alt_km", Beast),
             "down": ("alt_km", Bvert),
             "total": ("alt_km", Btotal),
+            "incl": ("alt_km", incl),
+            "decl": ("alt_km", decl),
         },
         coords={"alt_km": alt_km},
         attrs={"time": time, "isv": isv, "itype": itype, "glat": glat, "glon": glon},
     )
 
-    decl, incl = mag_vector2incl_decl(mag.north, mag.east, mag.down)
-
-    mag["incl"] = ("alt_km", incl)
-    mag["decl"] = ("alt_km", decl)
 
     return mag


### PR DESCRIPTION
Python 3.9.6 in Mac
There was error when running your example code like below

base.py line 144
-> TypeError: Using a DataArray object to construct a variable is ambiguous, please extract the data using the .data property.

So I fixed some code about 'incl' and 'decl' in igrf function

Thank you for your code