### PR TITLE
Fix bug introduced by new xarray behaviour v0.19.0

### DIFF
--- a/src/igrf/base.py
+++ b/src/igrf/base.py
@@ -83,8 +83,8 @@ def grid(
 
     decl, incl = mag_vector2incl_decl(mag.north, mag.east, mag.down)
 
-    mag["incl"] = (("glat", "glon"), incl)
-    mag["decl"] = (("glat", "glon"), decl)
+    mag["incl"] = (("glat", "glon"), incl.data)
+    mag["decl"] = (("glat", "glon"), decl.data)
 
     return mag
 
@@ -141,7 +141,7 @@ def igrf(
 
     decl, incl = mag_vector2incl_decl(mag.north, mag.east, mag.down)
 
-    mag["incl"] = ("alt_km", incl)
-    mag["decl"] = ("alt_km", decl)
+    mag["incl"] = ("alt_km", incl.data)
+    mag["decl"] = ("alt_km", decl.data)
 
     return mag


### PR DESCRIPTION
Attempting to use this package with the latest version of xarray, v0.19.0, fails due to a change in behaviour in XArray (which has affected several projects I use). When running the example `igrf.igrf()`, you get the following error: 

```
TypeError: Using a DataArray object to construct a variable is ambiguous, please extract the data using the .data property.
```

This occurs when setting the magnetic inclination and declination values into the existing xarray dataset. This PR fixes this issue on v0.19.0 and should be backwards compatible with prior xarray versions.